### PR TITLE
Fix bug introduced in #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,31 @@ googleFinance.historical({
 });
 ```
 
+### Specifying request options
+
+Optionally request options (such as a proxy) can be specified by inserting an
+extra parameter just before the callback:
+
+
+```js
+var httpRequestOptions = {
+  proxy: 'http://localproxy.com'
+};
+
+googleFinance.companyNews({
+  symbol: SYMBOL
+}, httpRequestOptions, function (err, news) {
+  // Result
+});
+
+googleFinance.historical({
+  symbol: SYMBOL,
+  from: START_DATE,
+  to: END_DATE
+}, httpRequestOptions, function (err, quotes) {
+  // Result
+});
+```
 
 ## Credits
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -133,6 +133,11 @@ function companyNews(options, optionalHttpRequestOptions, cb) {
   if (_.isUndefined(options)) { options = {}; }
   _sanitizeCompanyNews(options);
 
+  if(optionalHttpRequestOptions && typeof optionalHttpRequestOptions == 'function') {
+    cb = optionalHttpRequestOptions;
+    optionalHttpRequestOptions = undefined;
+  }
+
   var symbols = options.symbols || _.flatten([options.symbol]);
 
   return Promise.resolve(symbols)
@@ -174,6 +179,11 @@ function companyNews(options, optionalHttpRequestOptions, cb) {
 function historical(options, optionalHttpRequestOptions, cb) {
   if (_.isUndefined(options)) { options = {}; }
   _sanitizeHistorical(options);
+
+  if(optionalHttpRequestOptions && typeof optionalHttpRequestOptions == 'function') {
+    cb = optionalHttpRequestOptions;
+    optionalHttpRequestOptions = undefined;
+  }
 
   var symbols = options.symbols || _.flatten([options.symbol]);
 


### PR DESCRIPTION
Fixed backwards compatibility bug introduced by #8, the `optionalHttpRequestOptions` parameter is now really optional.

Also documented the new parameter.

