### PR TITLE
companyNews: calculate params.start correctly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -148,7 +148,7 @@ function companyNews(options, optionalHttpRequestOptions, cb) {
           var params = { output: 'rss', q: symbol, num: DEFAULT_PAGE_SIZE, start: DEFAULT_PAGE };
 
           if(!isNaN(options.page_size)) params.num = options.page_size;
-          if(!isNaN(options.page)) params.start = options.page - 1;
+          if(!isNaN(options.page)) params.start = (options.page - 1) * params.num;
 
           return _utils.downloadRSS(_constants.COMPANY_NEWS_URL, params, optionalHttpRequestOptions);
         })


### PR DESCRIPTION
the starting index of the first rss entry depends on params.num