### PR TITLE
Updated Historical URL

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,2 +1,2 @@
 exports.COMPANY_NEWS_URL = 'https://www.google.com/finance/company_news';
-exports.HISTORICAL_URL = 'http://www.google.com/finance/historical';
+exports.HISTORICAL_URL = 'http://finance.google.com/finance/historical';


### PR DESCRIPTION
The googleFinance.historical method was returning the wrong historical data.  Updating this URL fixes the problem.